### PR TITLE
chore(ci): 경로 무시 옵션 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore: "**.md"
   
   pull_request:
     branches: [main]
-    paths-ignore: "**.md"
 
   release:
     types: [published]


### PR DESCRIPTION
main브랜치에 머지 하기 하기 위해서는 3가지의 상태검사를 통과해야 합니다.

문서를 수정한경우 ci가 트리거 되지 않기 때문에 이 문제를 해결합니다.