### PR TITLE
fix(datetime): 일부 플랫폼에서의 UnicodeError 수정

### DIFF
--- a/crenata/utils/datetime.py
+++ b/crenata/utils/datetime.py
@@ -38,7 +38,7 @@ def datetime_to_readable(date: datetime) -> str:
     """
     datetime을 YYYY년 MM월 DD일 형식의 문자열로 변환합니다.
     """
-    return date.strftime("%Y년 %m월 %d일")
+    return date.strftime("%Y{} %m{} %d{}").format("년", "월", "일")
 
 
 def to_weekday(date: datetime) -> str:


### PR DESCRIPTION
이슈 #7 이`wontfix` 태그로 닫히긴 했지만, 일부 플랫폼, 특히 사람들이 많이 사용하는 Windows 환경에서는 한글을 인코딩할 수 없거나 올바르게 인코딩하지 않는 로케일이 설정되어 있을 수 있습니다.

`str.format()` 함수를 사용해서 간단한 수정으로 오류를 수정합니다.
`{`과 `}`는 ASCII 문자이므로 모든 플랫폼에서 인코딩 문제가 일어나지 않음을 보장할 수 있습니다.