### PR TITLE
feat: 명령어의 date 인자에 “내일” 키워드 인식

### DIFF
--- a/crenata/discord/commands/school/meal.py
+++ b/crenata/discord/commands/school/meal.py
@@ -12,7 +12,7 @@ from discord import app_commands
 @school.command(name="급식", description="급식 식단표를 가져와요.")
 @app_commands.describe(school_name="학교 이름")
 @app_commands.describe(meal_time="시간")
-@app_commands.describe(date="날짜 (예시: 20230101)")
+@app_commands.describe(date="날짜 (예시: 20230101, 내일)")
 async def meal(
     interaction: CrenataInteraction,
     school_name: Optional[str] = None,

--- a/crenata/discord/commands/school/timetable.py
+++ b/crenata/discord/commands/school/timetable.py
@@ -13,7 +13,7 @@ from discord import File, app_commands
 @app_commands.describe(school_name="학교 이름")
 @app_commands.describe(grade="학년")
 @app_commands.describe(room="반")
-@app_commands.describe(date="날짜 (예시: 20230101)")
+@app_commands.describe(date="날짜 (예시: 20230101, 내일)")
 async def time_table(
     interaction: CrenataInteraction,
     school_name: Optional[str] = None,

--- a/crenata/exception.py
+++ b/crenata/exception.py
@@ -30,7 +30,7 @@ class NeedSchoolName(CrenataException):
 
 
 class DateParseError(CrenataException):
-    """날짜를 잘못 입력한것 같아요. YYYYMMDD 형식, 또는 "어제, 내일"로 입력해주세요. 예: 20220110, 내일"""
+    """날짜를 잘못 입력한것 같아요. YYYYMMDD 형식, 또는 "내일"로 입력해주세요. 예: 20220110, 내일"""
 
 
 class MustBeGreaterThanOne(CrenataException):

--- a/crenata/exception.py
+++ b/crenata/exception.py
@@ -30,7 +30,7 @@ class NeedSchoolName(CrenataException):
 
 
 class DateParseError(CrenataException):
-    """날짜를 잘못 입력한것 같아요. YYYYMMDD 형식으로 입력해주세요. 예: 20220110"""
+    """날짜를 잘못 입력한것 같아요. YYYYMMDD 형식, 또는 "어제, 내일"로 입력해주세요. 예: 20220110, 내일"""
 
 
 class MustBeGreaterThanOne(CrenataException):

--- a/crenata/utils/datetime.py
+++ b/crenata/utils/datetime.py
@@ -56,7 +56,5 @@ def to_relative_date(keyword: str) -> Optional[datetime]:
     """
     if keyword == "내일":
         return datetime.now(KST) + timedelta(days=1)
-    elif keyword == "어제":
-        return datetime.now(KST) - timedelta(days=1)
     else:
         return None

--- a/crenata/utils/datetime.py
+++ b/crenata/utils/datetime.py
@@ -56,5 +56,4 @@ def to_relative_date(keyword: str) -> Optional[datetime]:
     """
     if keyword == "내일":
         return datetime.now(KST) + timedelta(days=1)
-    else:
-        return None
+    return None

--- a/crenata/utils/datetime.py
+++ b/crenata/utils/datetime.py
@@ -1,5 +1,5 @@
-from datetime import datetime
-from typing import Any, Callable, Coroutine
+from datetime import datetime, timedelta
+from typing import Any, Callable, Coroutine, Optional
 
 from crenata.typing import P, T
 from neispy.utils import KST
@@ -48,3 +48,15 @@ def to_weekday(date: datetime) -> str:
     days = ["월", "화", "수", "목", "금", "토", "일"]
     day = date.weekday()
     return days[day]
+
+
+def to_relative_date(keyword: str) -> Optional[datetime]:
+    """
+    "내일"과 같은 상대적인 날짜를 datetime으로 변환합니다.
+    """
+    if keyword == "내일":
+        return datetime.now(KST) + timedelta(days=1)
+    elif keyword == "어제":
+        return datetime.now(KST) - timedelta(days=1)
+    else:
+        return None

--- a/crenata/utils/discord.py
+++ b/crenata/utils/discord.py
@@ -3,7 +3,7 @@ from types import TracebackType
 from typing import Any, Callable, Coroutine, Optional
 
 from crenata.exception import DateParseError, InteractionLocked
-from crenata.utils.datetime import to_datetime
+from crenata.utils.datetime import to_datetime, to_relative_date
 from discord import Interaction, InteractionMessage, app_commands
 from discord.errors import NotFound
 from discord.utils import MISSING
@@ -44,7 +44,7 @@ class InteractionLock:
 class ToDatetime(app_commands.Transformer):
     async def transform(self, interaction: Interaction, date: str) -> datetime:
         try:
-            return to_datetime(date)
+            return to_relative_date(date) or to_datetime(date)
         except ValueError:
             raise DateParseError
 


### PR DESCRIPTION
## 추가된 기능
- `/학교 급식`과 `/학교 시간표` 명령어의 `date` 인자에서 "내일" 키워드를 인식해 내일 날짜를 사용 - #3

close https://github.com/team-crescendo/Crenata/issues/3