### PR TITLE
fix: matplotlib 사용 backend 수정

### DIFF
--- a/crenata/discord/timetable.py
+++ b/crenata/discord/timetable.py
@@ -4,9 +4,12 @@ from datetime import datetime
 from io import BytesIO
 from typing import Any, Optional
 
+import matplotlib  # type: ignore[import]
 import numpy as np
 import pandas as pd  # type: ignore[import]
-from matplotlib import font_manager  # type: ignore[import]
+
+matplotlib.use("Agg")
+from matplotlib import font_manager
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure  # type: ignore[import]
 


### PR DESCRIPTION
# 오류사항
크레나타 에서 ``/학교 시간표`` 명령어 사용시 시간표 출력이 잘 수행되지 않음

# 오류로그

```
Traceback (most recent call last):
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\discord\app_commands\commands.py", line 862, in _do_call
    return await self._callback(interaction, **params)  # type: ignore
  File "C:\Users\USER\Desktop\코딩\Crenata\crenata\discord\commands\school\timetable.py", line 45, in time_table
    embed, image = await time_table_embed_maker(
  File "C:\Users\USER\Desktop\코딩\Crenata\crenata\discord\embed.py", line 107, in time_table_embed_maker
    image = await make_timetable_image(results, date)
  File "C:\Users\USER\Desktop\코딩\Crenata\crenata\discord\timetable.py", line 93, in make_timetable_image
    await asyncio.to_thread(
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.2800.0_x64__qbz5n2kfra8p0\lib\asyncio\threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.2800.0_x64__qbz5n2kfra8p0\lib\concurrent\futures\thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\figure.py", line 3285, in savefig
    self.canvas.print_figure(fname, **kwargs)
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\backend_bases.py", line 2308, in print_figure
    renderer = _get_renderer(
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\backend_bases.py", line 1559, in _get_renderer
    print_method(io.BytesIO())
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\backend_bases.py", line 2204, in <lambda>
    print_method = functools.wraps(meth)(lambda *args, **kwargs: meth(
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\_api\deprecation.py", line 410, in wrapper
    return func(*inner_args, **inner_kwargs)
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\backends\backend_agg.py", line 517, in print_png
    self._print_pil(filename_or_obj, "png", pil_kwargs, metadata)
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\backends\backend_agg.py", line 463, in _print_pil
    FigureCanvasAgg.draw(self)
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\backends\backend_agg.py", line 402, in draw
    with RendererAgg.lock, \
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.2800.0_x64__qbz5n2kfra8p0\lib\contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\backend_bases.py", line 3047, in _wait_cursor_for_draw_cm
    self.canvas.set_cursor(self._last_cursor)
  File "C:\Users\USER\Desktop\코딩\Crenata\.venv\lib\site-packages\matplotlib\backends\_backend_tk.py", line 408, in set_cursor
    self._tkcanvas.configure(cursor=cursord[cursor])
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.2800.0_x64__qbz5n2kfra8p0\lib\tkinter\__init__.py", line 1675, in configure
    return self._configure('configure', cnf, kw)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.2800.0_x64__qbz5n2kfra8p0\lib\tkinter\__init__.py", line 1665, in _configure
    self.tk.call(_flatten((self._w, cmd)) + self._options(cnf))
RuntimeError: main thread is not in main loop
```

# 오류 원인 파악
해당 오류는 Matplotlib 라이브러리의 ``save_fig`` 함수가 별도의 스레드에서 실행되기 때문에 발생한 오류로 파악됩니다. 
Matplotlib 라이브러리의 GUI 벡엔드는 메인 스레드에서 실행되어야 하기 때문에 비대화형 벡엔드인 "Agg"로 변경하는 것으로 해결 할 수 있습니다.

# 레퍼런스
1. <https://devpress.csdn.net/python/63045c767e6682346619a830.html>
2. <https://matplotlib.org/stable/users/faq/howto_faq.html#work-with-threads>

