### PR TITLE
fix: timetable 잘림현상 수정

### DIFF
--- a/crenata/discord/timetable.py
+++ b/crenata/discord/timetable.py
@@ -80,7 +80,8 @@ async def make_timetable_image(results: list[list[Any]], date: datetime) -> Byte
             timetable.append(r.ITRT_CNTNT)
             day = to_weekday(to_datetime(r.ALL_TI_YMD))
 
-        df[day] = pd.Series(timetable)
+        tmp = pd.DataFrame({day: timetable})
+        df = pd.concat([df, tmp], axis=1)
 
     df.index += 1
     df.fillna("", inplace=True)


### PR DESCRIPTION
# 오류사항
[fix: matplotlib 사용 backend 수정](https://github.com/team-crescendo/Crenata/pull/13#issuecomment-1466219460) 에서 언급된 오류에 대한 것 입니다.

해당 버그는 ``/학교 시간표 school_name: 덕천중학교 grade: 1 room: 1`` 명령어를 통해 재현되었습니다.

# 오류 원인 파악
![image](https://user-images.githubusercontent.com/77389715/224778047-64a51bc2-74db-4b19-b7e7-b3302c24e13a.png)
디버그 필드에 보면 results가 가지고 있는 인자는 0(월요일에 해당)번째 리스트의 길이가 6(6교시) 이고 1(화요일에 해당)번째 리스트의 길이가 7(7교시에 해당) 함을 보이므로, 정상적으로 데이터를 불러왔음을 알 수 있습니다.

![image](https://user-images.githubusercontent.com/77389715/224778159-3a2627a0-9383-462d-b5c4-a6ad7137ce57.png)
그러고나서 results의 있는 시간표가 79-86번째 루프를 돌며 Dataframe으로 전환되고나서 df의 shape가 (6,5)임을 확인할 수 있습니다.  (columns인 월 ... 금을 제외한값) 이는 기대되는 값인 (7,5)와 다른 값입니다.

이에 대한 결과는 아래와 같습니다.
![image](https://user-images.githubusercontent.com/77389715/224778213-05f06fe1-e1f6-4932-8c84-a373b558bc13.png)

이는 기존에 사용된 df[day] = pd.Seires(timetable) 에서 pd.Seires가 df의 shape에 맞추기 때문에 일어나는 일입니다.
때문에 result를 df로 변환할때 각 shape가 보존 될 수 있도록 처리해야합니다.
그리고 수정된 코드를 사용하여 만들어진 시간표는 다음과 같은 결과를 얻습니다.
![image](https://user-images.githubusercontent.com/77389715/224778330-396bcb21-cf64-4200-8ca0-d1598f7d3648.png)

