### PR TITLE
fix: remove whitespace before convert to datetime

### DIFF
--- a/crenata/utils/datetime.py
+++ b/crenata/utils/datetime.py
@@ -24,7 +24,7 @@ def to_datetime(date: str) -> datetime:
     """
     YYYYMMDD 형식의 문자열을 datetime으로 변환합니다.
     """
-    return datetime.strptime(date, "%Y%m%d")
+    return datetime.strptime(date.strip(), "%Y%m%d")
 
 
 def to_yyyymmdd(datetime: datetime) -> str:

--- a/tests/test_neispy.py
+++ b/tests/test_neispy.py
@@ -32,14 +32,14 @@ async def test_get_meal_not_found(neispy: CrenataNeispy):
 @pytest.mark.asyncio
 async def test_get_time_table(neispy: CrenataNeispy):
     result = await neispy.get_time_table(
-        "E10", "7341068", "구월중학교", 1, 1, date=to_datetime("20220525")
+        "E10", "7341068", "구월중학교", 1, 1, date=to_datetime("20230525")
     )
     assert result
 
 
 @pytest.mark.asyncio
 async def test_get_week_time_table(neispy: CrenataNeispy):
-    d = to_datetime("20220525")
+    d = to_datetime("20230525")
     results, date = await neispy.get_week_time_table(
         "E10", "7341068", "구월중학교", 1, 1, date=d
     )


### PR DESCRIPTION
closes #35 

`LOAD_DTM`를 제외한 다른 값에서도 비슷한 오류가 발생할 수 있기 때문에 `to_datetime` 함수 내부에서 공백 제거