### PR TITLE
fix(database): postgresql에서 overflow 버그 수정

### DIFF
--- a/crenata/database/schema/mixin.py
+++ b/crenata/database/schema/mixin.py
@@ -12,7 +12,9 @@ class Schema:
     모든 스키마는 이 클래스를 상속받습니다.
     """
 
-    id: Mapped[int] = mapped_column(default=None, kw_only=True, primary_key=True)
+    id: Mapped[int] = mapped_column(
+        BigInteger, default=None, kw_only=True, primary_key=True
+    )
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
Schema 클래스의 id 타입을 BigInteger로 변경하여 해결하였습니다.
다만, 테스트 환경에서 아래와 같은 문제가 있었습니다.

- sqlite+aiosqlite:///:memory: 환경에서 실행했을 때
```ERROR tests/test_preferences.py::test_preferences_read - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id
ERROR tests/test_preferences.py::test_preferences_update - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id
ERROR tests/test_preferences.py::test_preferences_delete - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id
ERROR tests/test_school_info.py::test_school_info_read - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id
ERROR tests/test_school_info.py::test_school_info_update - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id
ERROR tests/test_school_info.py::test_school_info_delete - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id
ERROR tests/test_user.py::test_user_read - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id
ERROR tests/test_user.py::test_user_update - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id
ERROR tests/test_user.py::test_user_delete - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id
ERROR tests/test_user.py::test_user_read_from_school_info - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: preferences.id```